### PR TITLE
feat: add sidebar toggle functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,11 @@
         "command": "packy-usage.showExplorer",
         "title": "Show Usage Explorer",
         "category": "Packy Usage"
+      },
+      {
+        "command": "packy-usage.toggleSidebar",
+        "title": "Toggle Sidebar",
+        "category": "Packy Usage"
       }
     ],
     "configuration": {
@@ -74,6 +79,12 @@
           "type": "string",
           "default": "https://www.packycode.com/api/backend/users/info",
           "description": "API endpoint for budget data",
+          "scope": "application"
+        },
+        "packy-usage.showSidebar": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show or hide the Packy Usage sidebar panel",
           "scope": "application"
         }
       }
@@ -92,7 +103,7 @@
         {
           "id": "packy-usage.explorer",
           "name": "Usage Explorer",
-          "when": "true"
+          "when": "config.packy-usage.showSidebar"
         }
       ]
     },

--- a/src/controllers/command.controller.ts
+++ b/src/controllers/command.controller.ts
@@ -54,6 +54,9 @@ export class CommandController {
       ),
       vscode.commands.registerCommand("packy-usage.showExplorer", () =>
         this.handleShowExplorer()
+      ),
+      vscode.commands.registerCommand("packy-usage.toggleSidebar", () =>
+        this.handleToggleSidebar()
       )
     ]
   }
@@ -172,6 +175,21 @@ export class CommandController {
    */
   private handleShowExplorer(): void {
     vscode.commands.executeCommand("packy-usage.explorer.focus")
+  }
+
+  /**
+   * 处理切换侧边栏显示状态命令
+   */
+  private async handleToggleSidebar(): Promise<void> {
+    try {
+      const newVisible = await this.configService.toggleSidebarVisible()
+      const message = newVisible ? "侧边栏已显示" : "侧边栏已隐藏"
+      vscode.window.showInformationMessage(message)
+    } catch (error) {
+      vscode.window.showErrorMessage(
+        `切换侧边栏状态失败: ${(error as Error).message}`
+      )
+    }
   }
 
   /**

--- a/src/services/config.service.ts
+++ b/src/services/config.service.ts
@@ -14,6 +14,8 @@ export interface PluginConfig {
   pollingInterval: number
   /** 状态栏刷新间隔（毫秒） */
   statusBarRefreshInterval: number
+  /** 是否显示侧边栏 */
+  showSidebar: boolean
 }
 
 /**
@@ -30,7 +32,8 @@ export class ConfigService {
     apiEndpoint: "https://www.packycode.com/api/backend/users/info",
     enablePolling: true,
     pollingInterval: 30000, // 30秒
-    statusBarRefreshInterval: 1000 // 1秒
+    statusBarRefreshInterval: 1000, // 1秒
+    showSidebar: true
   }
 
   /**
@@ -76,6 +79,10 @@ export class ConfigService {
       statusBarRefreshInterval: config.get<number>(
         "statusBarRefreshInterval",
         ConfigService.DEFAULT_CONFIG.statusBarRefreshInterval
+      ),
+      showSidebar: config.get<boolean>(
+        "showSidebar",
+        ConfigService.DEFAULT_CONFIG.showSidebar
       )
     }
   }
@@ -90,6 +97,7 @@ export class ConfigService {
 - 轮询间隔: ${config.pollingInterval}ms
 - 启用轮询: ${config.enablePolling}
 - 状态栏刷新: ${config.statusBarRefreshInterval}ms
+- 侧边栏显示: ${config.showSidebar}
 - Token配置: ${config.apiToken ? "已配置" : "未配置"}`
   }
 
@@ -124,6 +132,15 @@ export class ConfigService {
     return vscode.workspace
       .getConfiguration(ConfigService.CONFIG_SECTION)
       .get<boolean>("enablePolling", ConfigService.DEFAULT_CONFIG.enablePolling)
+  }
+
+  /**
+   * 获取是否显示侧边栏
+   */
+  isSidebarVisible(): boolean {
+    return vscode.workspace
+      .getConfiguration(ConfigService.CONFIG_SECTION)
+      .get<boolean>("showSidebar", ConfigService.DEFAULT_CONFIG.showSidebar)
   }
 
   /**
@@ -167,6 +184,11 @@ export class ConfigService {
         "statusBarRefreshInterval",
         ConfigService.DEFAULT_CONFIG.statusBarRefreshInterval,
         vscode.ConfigurationTarget.Global
+      ),
+      config.update(
+        "showSidebar",
+        ConfigService.DEFAULT_CONFIG.showSidebar,
+        vscode.ConfigurationTarget.Global
       )
     ])
   }
@@ -178,6 +200,25 @@ export class ConfigService {
     await vscode.workspace
       .getConfiguration(ConfigService.CONFIG_SECTION)
       .update("apiToken", token, vscode.ConfigurationTarget.Global)
+  }
+
+  /**
+   * 设置侧边栏显示状态
+   */
+  async setSidebarVisible(visible: boolean): Promise<void> {
+    await vscode.workspace
+      .getConfiguration(ConfigService.CONFIG_SECTION)
+      .update("showSidebar", visible, vscode.ConfigurationTarget.Global)
+  }
+
+  /**
+   * 切换侧边栏显示状态
+   */
+  async toggleSidebarVisible(): Promise<boolean> {
+    const currentVisible = this.isSidebarVisible()
+    const newVisible = !currentVisible
+    await this.setSidebarVisible(newVisible)
+    return newVisible
   }
 
   /**


### PR DESCRIPTION
## Summary
- Add `showSidebar` configuration option with default value `true`
- Add `toggleSidebar` command to show/hide sidebar panel  
- Update view `when` condition to respond to `showSidebar` config
- Add ConfigService methods for sidebar visibility management
- Support both command palette and settings-based control

## Test plan
- [x] Sidebar toggles correctly via command palette "Toggle Sidebar"  
- [x] Sidebar responds to settings change for `packy-usage.showSidebar`
- [x] Default behavior (sidebar shown) works as expected
- [x] Plugin compiles and packages successfully
- [x] No breaking changes to existing functionality